### PR TITLE
Fix where redirection to landing page from login causes a runtime error #18

### DIFF
--- a/src/app/(general)/dashboard/page.jsx
+++ b/src/app/(general)/dashboard/page.jsx
@@ -20,16 +20,6 @@ import {
 } from "@tanstack/react-table";
 
 const Dashboard = () => {
-  const { data: session, status } = useSession();
-
-  if (status === "loading") {
-    return <Loader color="yellow" size="xl" />;
-  }
-
-  if (status === "unauthenticated") {
-    return <h1>Not Logged In</h1>;
-  }
-
   const current = usePathname();
   const iconStyle = { width: rem(20), height: rem(20) };
   const prisma = new PrismaClient();


### PR DESCRIPTION
# Fix where redirection to landing page from login causes a runtime error #18

## Details

Removed faulty route protection for `/dashboard`

Closes #18 

## Juxtaposition

![image](https://github.com/SE-Nex-Tech/Nex.Tech/assets/103241997/1381f62f-cae7-4861-baad-1533cc08b234)
