### PR TITLE
Books API Sorting

### DIFF
--- a/src/app/(general)/api/books/route.js
+++ b/src/app/(general)/api/books/route.js
@@ -5,7 +5,11 @@ const prisma = new PrismaClient();
 
 export async function GET(request) {
   const params = Object.fromEntries(await request.nextUrl.searchParams);
-  const books = await prisma.books.findMany();
+  const books = await prisma.books.findMany({
+    orderBy: {
+      id: "asc",
+    }
+  });
   // console.log(params['andy'] == 'value');
   return NextResponse.json(books);
 }


### PR DESCRIPTION
# Books API Sorting

## Details

Added an `orderBy` condition to the `/books` api to sort them properly at catalog view

## Juxtaposition

The catalog before would push recently edited entries to the very last of the list when querying a database table
![image](https://github.com/SE-Nex-Tech/Nex.Tech/assets/101425498/5acfe494-d321-4e17-b6d1-06acc3d05f50)

Now even after users borrow a book, it would retain its position in the pagination according to its `id`
![image](https://github.com/SE-Nex-Tech/Nex.Tech/assets/101425498/d8da47d4-e6a3-438f-bee1-c783273768ab)

